### PR TITLE
add move function for transferring in terms of dai amounts

### DIFF
--- a/src/chai.sol
+++ b/src/chai.sol
@@ -108,6 +108,11 @@ contract Chai {
     function transfer(address dst, uint wad) external returns (bool) {
         return transferFrom(msg.sender, dst, wad);
     }
+    // like transferFrom but dai-denominated
+    function move(address src, address dst, uint wad) external returns (bool) {
+        uint chi = (now > pot.rho()) ? pot.drip() : pot.chi();
+        return transferFrom(src, dst, rdiv(wad, chi));
+    }
     function transferFrom(address src, address dst, uint wad)
         public returns (bool)
     {

--- a/src/chai.sol
+++ b/src/chai.sol
@@ -78,6 +78,10 @@ contract Chai {
         // always rounds down
         z = mul(x, RAY) / y;
     }
+    function rdivup(uint x, uint y) internal pure returns (uint z) {
+        // always rounds up
+        z = add(mul(x, RAY), sub(y, 1)) / y;
+    }
 
     // --- EIP712 niceties ---
     bytes32 public DOMAIN_SEPARATOR;
@@ -111,7 +115,8 @@ contract Chai {
     // like transferFrom but dai-denominated
     function move(address src, address dst, uint wad) external returns (bool) {
         uint chi = (now > pot.rho()) ? pot.drip() : pot.chi();
-        return transferFrom(src, dst, rdiv(wad, chi));
+        // rounding up ensures dst gets at least wad dai
+        return transferFrom(src, dst, rdivup(wad, chi));
     }
     function transferFrom(address src, address dst, uint wad)
         public returns (bool)

--- a/src/chai.sol
+++ b/src/chai.sol
@@ -191,4 +191,11 @@ contract Chai {
         daiJoin.exit(msg.sender, rmul(chi, wad));
         emit Transfer(src, address(0), wad);
     }
+
+    // wad is denominated in dai
+    function draw(address src, uint wad) external {
+        uint chi = (now > pot.rho()) ? pot.drip() : pot.chi();
+        // rounding up ensures usr gets at least wad dai
+        exit(src, rdivup(wad, chi));
+    }
 }

--- a/src/chai.sol
+++ b/src/chai.sol
@@ -177,18 +177,18 @@ contract Chai {
     }
 
     // wad is denominated in (1/chi) * dai
-    function exit(address usr, uint wad) external {
-        require(balanceOf[usr] >= wad, "chai/insufficient-balance");
-        if (usr != msg.sender && allowance[usr][msg.sender] != uint(-1)) {
-            require(allowance[usr][msg.sender] >= wad, "chai/insufficient-allowance");
-            allowance[usr][msg.sender] = sub(allowance[usr][msg.sender], wad);
+    function exit(address src, uint wad) public {
+        require(balanceOf[src] >= wad, "chai/insufficient-balance");
+        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
+            require(allowance[src][msg.sender] >= wad, "chai/insufficient-allowance");
+            allowance[src][msg.sender] = sub(allowance[src][msg.sender], wad);
         }
-        balanceOf[usr] = sub(balanceOf[usr], wad);
+        balanceOf[src] = sub(balanceOf[src], wad);
         totalSupply    = sub(totalSupply, wad);
 
         uint chi = (now > pot.rho()) ? pot.drip() : pot.chi();
         pot.exit(wad);
         daiJoin.exit(msg.sender, rmul(chi, wad));
-        emit Transfer(usr, address(0), wad);
+        emit Transfer(src, address(0), wad);
     }
 }

--- a/src/test/chai.t.sol
+++ b/src/test/chai.t.sol
@@ -146,7 +146,7 @@ contract ChaiTest is DSTest, ChaiSetup {
         chai.join(address(this), 10 ether);
         uint chaiBal = rdiv(10 ether, pot.chi());
         assertEq(chai.balanceOf(address(this)), chaiBal);
-        // 1 wei lost to rounding
+        // 1 wei less due to rounding
         assertEq(chai.dai(address(this)), 10 ether - 1);
 
         hevm.warp(now + 1 days);

--- a/src/test/chai.t.sol
+++ b/src/test/chai.t.sol
@@ -197,6 +197,8 @@ contract ChaiTest is DSTest, ChaiSetup {
         assertEq(chai.dai(address(this)), 10 ether - 17 - 1 - 26);
         // cafebabe got no less than requested
         assertEq(chai.dai(address(0xcafebabe)), 0.5 ether + 25);
+        // chai is globally conserved
+        assertEq(chai.balanceOf(address(this)) + chai.balanceOf(address(0xcafebabe)), chaiBal);
 
         chai.exit(address(this), chai.balanceOf(address(this)));
         assertEq(dai.balanceOf(address(this)), 100 ether - 17 - 1 - 26);

--- a/src/test/chai.t.sol
+++ b/src/test/chai.t.sol
@@ -108,9 +108,11 @@ contract ChaiTest is DSTest, ChaiSetup {
 
     function test_save_1d() public {
         pot.file("dsr", uint(1000000564701133626865910626));  // 5% / day
+
         chai.join(address(this), 10 ether);
         assertEq(chai.balanceOf(address(this)), 10 ether);
         assertEq(chai.dai(address(this)), 10 ether);
+
         hevm.warp(now + 1 days);
         assertEq(chai.balanceOf(address(this)), 10 ether);
         assertEq(chai.dai(address(this)), 10 ether + 0.5 ether);
@@ -120,6 +122,7 @@ contract ChaiTest is DSTest, ChaiSetup {
 
     function test_save_2d() public {
         pot.file("dsr", uint(1000000564701133626865910626));  // 5% / day
+
         chai.join(address(this), 10 ether);
         assertEq(chai.balanceOf(address(this)), 10 ether);
         hevm.warp(now + 1 days);
@@ -154,6 +157,7 @@ contract ChaiTest is DSTest, ChaiSetup {
     }
     function test_move() public {
         pot.file("dsr", uint(1000000564701133626865910626));  // 5% / day
+
         chai.join(address(this), 10 ether);
         assertEq(chai.balanceOf(address(this)), 10 ether);
         assertEq(chai.dai(address(this)), 10 ether);
@@ -175,15 +179,16 @@ contract ChaiTest is DSTest, ChaiSetup {
         pot.file("dsr", uint(1000000564701133626865910626));  // 5% / day
         // make chi nasty
         hevm.warp(now + 100 days);
+
         chai.join(address(this), 10 ether);
         uint chaiBal = rdiv(10 ether, pot.chi());
         assertEq(chai.balanceOf(address(this)), chaiBal);
-        // 18 wei lost to rounding
+        // 17 wei less due to rounding
         assertEq(chai.dai(address(this)), 10 ether - 17);
 
         hevm.warp(now + 1 days);
         assertEq(chai.balanceOf(address(this)), chaiBal);
-        // 1 more wei lost to rounding
+        // 1 wei less due to rounding
         assertEq(chai.dai(address(this)), 10 ether + 0.5 ether - 17 - 1);
 
         chai.move(address(this), address(0xcafebabe), 0.5 ether);

--- a/src/test/chai.t.sol
+++ b/src/test/chai.t.sol
@@ -196,6 +196,29 @@ contract ChaiTest is DSTest, ChaiSetup {
         chai.exit(address(this), chai.balanceOf(address(this)));
         assertEq(dai.balanceOf(address(this)), 100 ether - 17 - 1 - 26);
     }
+    function test_draw() public {
+        pot.file("dsr", uint(1000000564701133626865910626));  // 5% / day
+        // make chi nasty
+        hevm.warp(now + 100 days);
+
+        chai.join(address(this), 10 ether);
+        uint chaiBal = rdiv(10 ether, pot.chi());
+        assertEq(chai.balanceOf(address(this)), chaiBal);
+        // 17 wei less due to rounding
+        assertEq(chai.dai(address(this)), 10 ether - 17);
+
+        hevm.warp(now + 1 days);
+        assertEq(chai.balanceOf(address(this)), chaiBal);
+        // 1 wei less due to rounding
+        assertEq(chai.dai(address(this)), 10 ether + 0.5 ether - 18);
+        chai.draw(address(this), 10 ether);
+        // withdrew 94 wei extra due to rounding
+        assertEq(dai.balanceOf(address(this)), 100 ether + 94);
+
+        chai.exit(address(this), chai.balanceOf(address(this)));
+        // 1 wei less due to rounding
+        assertEq(dai.balanceOf(address(this)), 100 ether + 0.5 ether - 18 - 1);
+    }
 }
 
 contract ChaiUser {

--- a/src/test/chai.t.sol
+++ b/src/test/chai.t.sol
@@ -152,6 +152,24 @@ contract ChaiTest is DSTest, ChaiSetup {
         chai.exit(address(this), chaiBal);
         assertEq(dai.balanceOf(address(this)), 100 ether + 0.5 ether - 1);
     }
+    function test_move() public {
+        pot.file("dsr", uint(1000000564701133626865910626));  // 5% / day
+        chai.join(address(this), 10 ether);
+        assertEq(chai.balanceOf(address(this)), 10 ether);
+        assertEq(chai.dai(address(this)), 10 ether);
+        hevm.warp(now + 1 days);
+        assertEq(chai.balanceOf(address(this)), 10 ether);
+        assertEq(chai.dai(address(this)), 10 ether + 0.5 ether);
+
+        chai.move(address(this), address(0xcafebabe), 0.5 ether);
+
+        assertEq(chai.dai(address(this)), 10 ether);
+        // cafebabe got one less than expected because of rounding :(
+        assertEq(chai.dai(address(0xcafebabe)), 0.5 ether - 1);
+
+        chai.exit(address(this), chai.balanceOf(address(this)));
+        assertEq(dai.balanceOf(address(this)), 100 ether);
+    }
 }
 
 contract ChaiUser {


### PR DESCRIPTION
`move` can be used for transfers where the transferor wishes to remit a given dai amount to the recipient.

`move(src, dst, wad)` has the property that `chai.dai(dst)` increases by _at least_ `wad`. Note that this is difficult to achieve without a contract wrapper/proxy because `chi` at tx execution time is not known in advance.